### PR TITLE
fix: Pin rsa to 4.5 for Python 2.7 compatibility

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -31,6 +31,8 @@ setup(
         'httplib2>=0.9.1,<=0.12.0',
         'oauth2client>=2.0.1,<4.0.0',
         'proto-google-cloud-datastore-v1>=0.90.0',
+        # rsa version 4.5 is the last version that is compatible with Python 2.7
+        "rsa==4.5;python_version<'3'",
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes #260

This PR pins `rsa` to 4.5 for python 2. [See the official blog](https://stuvel.eu/post/2020-06-18-python-rsa-4-6-released/) that mentions version 4.5 is the last one that supports python 2.