### PR TITLE
change to separate lines from one single line import pylint

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
example of lint incorrect code:
```python
import os, sys
```
correct:
```python
import os
import sys
```